### PR TITLE
Init warehouse sdk, block prediction/resolution methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # warehouse-sdk
+
 SDK for queries from https://warehouse.dex.guru/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pydantic
+requests

--- a/warehouse_sdk/__init__.py
+++ b/warehouse_sdk/__init__.py
@@ -1,0 +1,40 @@
+from time import sleep
+from typing import Optional
+
+import requests
+
+
+class BaseWarehouseService:
+    def __init__(self, warehouse_url: str, warehouse_api_key: str):
+        self._warehouse_url = warehouse_url
+        self._warehouse_api_key = warehouse_api_key
+
+    def _make_wh_request(self, query: str, parameters: dict, retry: int = 1) -> Optional[dict]:
+        url = f'{self._warehouse_url}/{query}?api_key={self._warehouse_api_key}'
+        headers = {'Content-Type': 'application/json'}
+        try:
+            response = requests.post(url, headers=headers, data=json.dumps(parameters))
+            if response.status_code == 200:
+                response_json = response.json()
+                if response_json:
+                    if response_json[0].get('job'):
+                        if retry:
+                            # retry as warehouse working on the job, there is no cached.
+                            sleep(1)
+                            return self._make_wh_request(query=query, parameters=parameters, retry=0)
+                        else:
+                            return None
+                    return response_json
+                else:
+                    return None
+            else:
+                return None
+        except Exception as e:
+            return None
+
+    @staticmethod
+    def _transform_timestamp(v: int):
+        # Check if timestamp is in milliseconds (assuming it's longer than 10 characters)
+        if len(str(v)) > 10:
+            v = round(v / 1000)
+        return v

--- a/warehouse_sdk/block_service.py
+++ b/warehouse_sdk/block_service.py
@@ -1,0 +1,147 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from warehouse_sdk import BaseWarehouseService
+
+
+class BlockModel(BaseModel):
+    number: int
+    timestamp: int
+    hash: Optional[str] = None
+    parent_hash: Optional[str] = None
+    nonce: Optional[str] = None
+    sha3_uncles: Optional[str] = None
+    logs_bloom: Optional[str] = None
+    transactions_root: Optional[str] = None
+    state_root: Optional[str] = None
+    receipts_root: Optional[str] = None
+    miner: Optional[str] = None
+    difficulty: Optional[str] = None
+    total_difficulty: Optional[str] = None
+    size: Optional[int] = None
+    extra_data: Optional[str] = None
+    gas_limit: Optional[int] = None
+    gas_used: Optional[int] = None
+    transaction_count: Optional[int] = None
+    base_fee_per_gas: Optional[int] = None
+
+
+class BlockService(BaseWarehouseService):
+
+    def get_last_indexed_block(self, network: str) -> Optional[list]:
+        """
+        We are requesting last indexed block from data warehouse
+        query:
+        https://warehouse.dex.guru/queries/15
+        curl -X POST 'https://api.dev.dex.guru/wh/last_block_indexed?api_key=YOUR_API_KEY'
+         -H 'Content-Type: application/json' --data '{"parameters": {"network":"canto"}}'
+        """
+        if network == "eth":
+            network = "ethereum"
+        return self._make_wh_request('last_block_indexed', {"parameters": {"network": network}})
+
+    def get_indexed_block_by_timestamp(self, network: str, timestamp: int) -> Optional[list]:
+        """
+        We are requesting block by timestamp from data warehouse
+        query
+        https://warehouse.dex.guru/queries/167
+
+        curl -X POST 'https://api.dev.dex.guru/wh/block_by_timestamp?api_key=YOUR_API_KEY'
+         -H 'Content-Type: application/json' --data '{"parameters": {"timestamp":"1703416371",
+         "Network":"ethereum","block_time":"14"}}'
+
+        """
+        if network == "eth":
+            network = "ethereum"
+        return self._make_wh_request('block_by_timestamp', {"parameters": {"timestamp": timestamp,
+                                                                           "network": network}})
+
+    def get_block_by_number(self, network: str, block_number: int) -> Optional[list]:
+        """
+        We are requesting block by number from data warehouse
+        query
+        https://warehouse.dex.guru/queries/169
+        curl -X POST 'https://api.dev.dex.guru/wh/block_by_number?api_key=YOUR_API_KEY'
+        -H 'Content-Type: application/json' --data '{"parameters": {"network":"ethereum","number":"1"}}'
+        """
+        if network == "eth":
+            network = "ethereum"
+        return self._make_wh_request('block_by_number', {"parameters": {"number": block_number,
+                                                                        "network": network}})
+
+    def get_lr_coefficients(self, network: str, training_set_size: int) -> Optional[list]:
+        """
+        We are requesting linear regression for network from warehouse
+        https://warehouse.dex.guru/queries/166
+
+        query curl -X POST 'https://api.dev.dex.guru/wh/block_ts_lr?api_key=YOUR_API_KEY'
+        -H 'Content-Type: application/json' --data '{"parameters": {"network":"ethereum","training_set_size":1000000}}'
+         -H 'Content-Type: application/json' --data '{"parameters": {"network":"canto"}}'
+         we reciewe json like this:
+         [{"block_number": 7463340, "block_timestamp": 1703379702, "block_lag": 5}]
+        """
+        if network == "eth":
+            network = "ethereum"
+        return self._make_wh_request('block_ts_lr', {"parameters": {"network": network,
+                                                                    "training_set_size": training_set_size}})
+
+    def get_block_by_timestamp(self, network: str,
+                               timestamp: int) -> Optional[BlockModel]:
+
+        """
+        Method either predicts or returns block by timestamp
+        :param network:
+        :param timestamp:
+        :return:
+        """
+        timestamp = self._transform_timestamp(timestamp)
+        last_indexed_block = self.get_last_indexed_block(network)
+        if not last_indexed_block:
+            return None
+        last_indexed_block = last_indexed_block[0]
+        if timestamp > last_indexed_block['timestamp']:
+            # 10% OF ALL BLOCKS
+            training_set_size = round(last_indexed_block['number'] * 0.1)
+            lr_coefficients = self.get_lr_coefficients(network, training_set_size)
+            if not lr_coefficients:
+                return None
+            lr_coefficients = lr_coefficients[0]['lr']
+            block_number = round((timestamp - lr_coefficients["b"]) // lr_coefficients["k"])
+            return BlockModel(number=block_number, timestamp=timestamp)
+        else:
+            block_by_timestamp = self.get_indexed_block_by_timestamp(network,
+                                                                     timestamp)
+            if not block_by_timestamp:
+                return None
+            block_by_timestamp = block_by_timestamp[0]
+            return BlockModel(**block_by_timestamp)
+
+    def get_block(self,
+                  network: str,
+                  block_number: int
+                  ) -> Optional[BlockModel]:
+        """
+        Method either predicts or returns block by number
+        :param network:
+        :param block_number:
+        :return:
+        """
+        last_indexed_block = self.get_last_indexed_block(network)
+        if not last_indexed_block:
+            return None
+        last_indexed_block = last_indexed_block[0]
+        if block_number > last_indexed_block['number']:
+            training_set_size = round(last_indexed_block['number'] * 0.1)
+            lr_coefficients = self.get_lr_coefficients(network, training_set_size)
+            if not lr_coefficients:
+                return None
+            lr_coefficients = lr_coefficients[0]['lr']
+            timestamp = round(lr_coefficients["k"] * block_number + lr_coefficients["b"])
+            return BlockModel(number=block_number, timestamp=timestamp)
+        else:
+            block = self.get_block_by_number(network, block_number)
+            if not block:
+                return None
+            block = block[0]
+            return BlockModel(**block)


### PR DESCRIPTION
Submitting warehouse SDK to work with warehouse queries, for processes where multiple requests are needed, like in those methods posted get_block_by_timestamp and get_block as those support not only getting existing block, but forking towards Simple Linear Regression predictions if those are in future.